### PR TITLE
Limit targets to 10 per user

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,4 @@
 export const TARGET_MAX_RADIUS = 2000
 export const TARGET_MIN_RADIUS = 0
+
+export const MAX_TARGETS = 10

--- a/src/dto/target.dto.ts
+++ b/src/dto/target.dto.ts
@@ -10,8 +10,8 @@ export default class CreateTargetDto {
     this.radius = target.radius
     this.latitude = target.latitude
     this.longitude = target.longitude
-    this.topic = target.topic
-    this.user = target.user
+    this.topic = new TopicDto(target.topic)
+    this.user = new UserDto(target.user)
   }
   @IsNotEmpty()
   readonly title: string

--- a/src/targets/max-targets.guard.ts
+++ b/src/targets/max-targets.guard.ts
@@ -1,0 +1,19 @@
+
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common'
+import { Observable } from 'rxjs'
+
+import { TargetsService } from './targets.service'
+
+@Injectable()
+export class MaxTargetsGuard implements CanActivate {
+  constructor(
+    readonly targetsService: TargetsService,
+  ) {}
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const { user } = context.switchToHttp().getRequest()
+    return this.targetsService.canCreateTargets(user)
+  }
+}

--- a/src/targets/targets.controller.ts
+++ b/src/targets/targets.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, UseGuards, Request, Body } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
 
 import { TargetsService } from './targets.service'
+import { MaxTargetsGuard } from './max-targets.guard'
 import CreateTargetDto from '../dto/create-target.dto'
 
 @Controller('targets')
@@ -10,7 +11,7 @@ export class TargetsController {
     private readonly targetservice: TargetsService,
   ) { }
 
-  @UseGuards(AuthGuard())
+  @UseGuards(AuthGuard(), MaxTargetsGuard)
   @Post()
   async create(
     @Request() { user },

--- a/src/targets/targets.service.ts
+++ b/src/targets/targets.service.ts
@@ -5,7 +5,8 @@ import { Repository } from 'typeorm'
 import { Target } from './target.entity'
 import { Topic } from '../topics/topic.entity'
 import { User } from '../users/user.entity'
-import { TargetDto } from '../dto'
+import { TargetDto, UserDto } from '../dto'
+import { MAX_TARGETS } from '../constants'
 
 @Injectable()
 export class TargetsService {
@@ -17,6 +18,11 @@ export class TargetsService {
     @InjectRepository(Topic)
     private readonly topicsRepository: Repository<Topic>,
   ) {}
+
+  async canCreateTargets(userInfo: UserDto): Promise<boolean> {
+    const user = await this.usersRepository.findOne(userInfo, { relations: ['targets'] })
+    return !user.targets || user.targets.length < MAX_TARGETS
+  } 
 
   async create(
     title: string,

--- a/test/get-topics.e2e-spec.ts
+++ b/test/get-topics.e2e-spec.ts
@@ -1,4 +1,4 @@
-import * as request from 'supertest'
+import request from 'supertest'
 import { Test } from '@nestjs/testing'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { INestApplication } from '@nestjs/common'

--- a/test/login.e2e-spec.ts
+++ b/test/login.e2e-spec.ts
@@ -1,4 +1,4 @@
-import * as request from 'supertest'
+import request from 'supertest'
 import { Test } from '@nestjs/testing'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { INestApplication } from '@nestjs/common'

--- a/test/signup.e2e-spec.ts
+++ b/test/signup.e2e-spec.ts
@@ -1,4 +1,4 @@
-import * as request from 'supertest'
+import request from 'supertest'
 import { Test } from '@nestjs/testing'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { INestApplication } from '@nestjs/common'

--- a/test/targets-repo.service.ts
+++ b/test/targets-repo.service.ts
@@ -1,7 +1,10 @@
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
+import { lorem, random, address } from 'faker'
 
+import { TopicsRepoService } from './topics-repo.service'
 import { Target } from '../src/targets/target.entity'
+import { User } from '../src/users/user.entity'
 
 export class TargetsRepoService {
   private salts: number
@@ -9,9 +12,28 @@ export class TargetsRepoService {
   constructor(
     @InjectRepository(Target)
     private readonly targetsRepository: Repository<Target>,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+    private readonly topicsService: TopicsRepoService,
   ) {}
 
   async last(): Promise<Target> {
     return this.targetsRepository.findOne({ relations: ['user', 'topic'] })
+  }
+
+  async mockMany(count: number, user: User): Promise<Target[]> {
+    const topic = await this.topicsService.mockOne()
+    const targets = []
+    for (let i = 0; i < count; i++) {
+      targets.push(new Target(
+        `${lorem.word()}${i}`,
+        random.number(),
+        parseFloat(address.latitude()),
+        parseFloat(address.longitude()),
+        user,
+        topic
+      ))
+    }
+    return this.targetsRepository.save(targets)
   }
 }

--- a/test/topics-repo.service.ts
+++ b/test/topics-repo.service.ts
@@ -3,7 +3,6 @@ import { Repository } from 'typeorm'
 import { lorem } from 'faker'
 
 import { Topic } from '../src/topics/topic.entity'
-import TopicDto from '../src/dto/topic.dto'
 
 export class TopicsRepoService {
   constructor(
@@ -14,16 +13,15 @@ export class TopicsRepoService {
 
   async mockOne(): Promise<Topic> {
     let topic = new Topic(lorem.word())
-    topic = await this.topicsRepository.save(topic) 
-    return new TopicDto(topic)
+    return this.topicsRepository.save(topic) 
   }
 
   async mockMany(count: number): Promise<Topic[]> {
     let topics = []
     for (let i = 0; i < count; i++) {
-      topics.push(new Topic(lorem.word()))
+      topics.push(new Topic(`${lorem.word()}${i}`))
     }
     topics = await this.topicsRepository.save(topics)
-    return topics.map(topic => new TopicDto(topic))
+    return topics
   }
 }

--- a/test/users-repo.service.ts
+++ b/test/users-repo.service.ts
@@ -1,10 +1,9 @@
 import { InjectRepository } from '@nestjs/typeorm'
-import * as request from 'supertest'
+import request from 'supertest'
 import { Repository } from 'typeorm'
 import { internet } from 'faker'
 
 import { User } from '../src/users/user.entity'
-import UserDto from '../src/dto/user.dto'
 import { hash } from 'bcrypt'
 import { ConfigService } from '../src/config/config.service'
 
@@ -30,7 +29,7 @@ export class UsersRepoService {
     return user
   }
 
-  async mockWithToken(app): Promise<{ user: UserDto, accessToken: string }> {
+  async mockWithToken(app): Promise<{ user: User, accessToken: string }> {
     const email = internet.email()
     const password = internet.password()
 
@@ -41,7 +40,7 @@ export class UsersRepoService {
       .expect('Content-Type', /json/)
 
     return {
-      user: new UserDto(user),
+      user,
       accessToken,
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "incremental": true
+    "incremental": true,
+    "esModuleInterop": true
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Implements a limit for user targets using a guard.
First custom guard!
Guards might be more of a authorization and permission kinda thing... But I thought it was still a good place to try one, since I don't think there will be many opportunities to use a custom guard in target.