### PR TITLE
Add matches feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5632,6 +5632,11 @@
         }
       }
     },
+    "geolib": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.0.4.tgz",
+      "integrity": "sha512-IpbpPdfuVdjj2T909H0Kj0Crp0he+xfFYX6e1Wlvo5L2OVkfnfvpTLp9k0VYuu5ObbWhQ/TI2VKNsrAokss5vA=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "class-transformer": "^0.2.3",
     "class-validator": "^0.10.2",
     "dotenv": "^8.2.0",
+    "geolib": "^3.0.4",
     "nest-schedule": "^0.6.3",
     "passport": "^0.4.0",
     "passport-jwt": "^4.0.0",

--- a/src/dto/create-target.dto.ts
+++ b/src/dto/create-target.dto.ts
@@ -12,10 +12,10 @@ export default class CreateTargetDto {
   readonly radius: number
 
   @IsNotEmpty()
-  readonly latitude: number
+  readonly latitude: string
 
   @IsNotEmpty()
-  readonly longitude: number
+  readonly longitude: string
 
   @IsNotEmpty()
   readonly topicId: number

--- a/src/dto/target.dto.ts
+++ b/src/dto/target.dto.ts
@@ -22,11 +22,11 @@ export default class TargetDto {
 
   @IsNotEmpty()
   @Expose()
-  readonly latitude: number
+  readonly latitude: string
 
   @IsNotEmpty()
   @Expose()
-  readonly longitude: number
+  readonly longitude: string
 
   @IsNotEmpty()
   @Expose()

--- a/src/targets/target.entity.ts
+++ b/src/targets/target.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, CreateDateColumn } from 'typeorm'
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, CreateDateColumn, ManyToMany, JoinTable } from 'typeorm'
 import { IsInt, Min, Max } from 'class-validator'
 
 import { TARGET_MAX_RADIUS, TARGET_MIN_RADIUS } from './target.constants'
@@ -10,10 +10,11 @@ export class Target {
   constructor(
     title: string,
     radius: number,
-    latitude: number,
-    longitude: number,
+    latitude: string,
+    longitude: string,
     user: User,
     topic: Topic,
+    matches?: Target[],
   ) {
     this.title = title
     this.radius = radius
@@ -21,6 +22,7 @@ export class Target {
     this.longitude = longitude
     this.user = user
     this.topic = topic
+    this.matches = matches
   }
 
   @PrimaryGeneratedColumn()
@@ -35,17 +37,21 @@ export class Target {
   @Column()
   radius: number
 
-  @Column('float')
-  latitude: number
+  @Column()
+  latitude: string
 
-  @Column('float')
-  longitude: number
+  @Column()
+  longitude: string
 
   @ManyToOne(() => User, user => user.targets, { nullable: false })
   user: User
 
   @ManyToOne(() => Topic, { nullable: false })
   topic: Topic
+
+  @ManyToMany(() => Target, target => target.matches, { cascade: ['update'] })
+  @JoinTable()
+  matches: Target[]
 
   @CreateDateColumn()
   createdAt: Date

--- a/src/targets/targets.controller.ts
+++ b/src/targets/targets.controller.ts
@@ -17,8 +17,8 @@ export class TargetsController {
   async create(
     @Request() { user },
     @Body() { title, radius, latitude, longitude, topicId }: CreateTargetDto,
-  ): Promise<TargetDto> {
-    const target = await this.targetservice.create(
+  ): Promise<{ target: TargetDto, matches: TargetDto[] }> {
+    const { target, matches } = await this.targetservice.create(
       title,
       radius,
       latitude,
@@ -26,7 +26,11 @@ export class TargetsController {
       user,
       topicId,
     )
-    return TargetDto.from(target)
+
+    return {
+      target: TargetDto.from(target),
+      matches: TargetDto.fromArray(matches),
+    }
   }
 
   @UseGuards(AuthGuard())

--- a/test/fixtures/target.fixture.ts
+++ b/test/fixtures/target.fixture.ts
@@ -1,0 +1,14 @@
+import { lorem, random, finance } from 'faker'
+
+export const generateCluttered = (ammount: number) => {
+  const mockTargets = []
+  for (let i = 0; i < ammount; i++) {
+    mockTargets.push({
+      title: `${lorem.word()}${i}`,
+      radius: random.number({ min:190, max:210 }),
+      latitude: finance.amount(43.0192, 43.0193, 6),
+      longitude: finance.amount(-23.9818, -23.9819, 6),
+    })
+  }
+  return mockTargets
+}

--- a/test/targets-repo.service.ts
+++ b/test/targets-repo.service.ts
@@ -21,13 +21,25 @@ export class TargetsRepoService {
     return this.targetsRepository.findOne({ relations: ['user', 'topic'] })
   }
 
+  async mockOneFromInfo(target, user, topic): Promise<Target> {
+    const newTarget = new Target(
+      target.title,
+      target.radius,
+      target.latitude,
+      target.longitude,
+      user,
+      topic
+    )
+    return this.targetsRepository.save(newTarget)
+  }
+
   async mockOne(user: User): Promise<Target> {
     const topic = await this.topicsService.mockOne()
     const target = new Target(
       lorem.word(),
       random.number(),
-      parseFloat(address.latitude()),
-      parseFloat(address.longitude()),
+      address.latitude(),
+      address.longitude(),
       user,
       topic
     )
@@ -45,8 +57,8 @@ export class TargetsRepoService {
       targets.push(new Target(
         `${lorem.word()}${i}`,
         random.number(),
-        parseFloat(address.latitude()),
-        parseFloat(address.longitude()),
+        address.latitude(),
+        address.longitude(),
         user,
         topic
       ))

--- a/test/targets/create-target.e2e-spec.ts
+++ b/test/targets/create-target.e2e-spec.ts
@@ -7,14 +7,15 @@ import { AuthModule } from '../../src/auth/auth.module'
 import { TopicsModule } from '../../src/topics/topics.module'
 import { TargetsModule } from '../../src/targets/targets.module'
 import { ConfigModule } from '../../src/config/config.module'
-import { TopicsRepoService } from '../topics-repo.service'
-import { UsersRepoService } from '../users-repo.service'
-import { TargetsRepoService } from '../targets-repo.service'
 import { Topic } from '../../src/topics/topic.entity'
 import { User } from '../../src/users/user.entity'
 import { Target } from '../../src/targets/target.entity'
 import { TargetDto } from '../../src/dto'
 import applyGlobalConfig from '../../src/apply-global-conf'
+import { TopicsRepoService } from '../topics-repo.service'
+import { UsersRepoService } from '../users-repo.service'
+import { TargetsRepoService } from '../targets-repo.service'
+import { generateCluttered } from '../fixtures/target.fixture'
 import ormAsyncOptions from '../orm-config'
 
 describe('POST /targets', () => {
@@ -25,21 +26,10 @@ describe('POST /targets', () => {
   let accessToken
   let targets
   let mockTopic
-  const mockTarget = {
-    title: 'Title',
-    radius: 200,
-    latitude: 43.019293,
-    longitude: -23.981819,
-  }
+  const mockTargets = generateCluttered(3)
+  let postTargets
 
-  const mockTarget2 = {
-    title: 'Title2',
-    radius: 200,
-    latitude: 43.019293,
-    longitude: -23.981819,
-  }
-
-  beforeAll(async () => {
+  beforeEach(async () => {
     const module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRootAsync(ormAsyncOptions),
@@ -62,60 +52,65 @@ describe('POST /targets', () => {
 
     mockTopic = await topics.mockOne()
     ; ({ user, accessToken } = await users.mockWithToken(app))
+
+    postTargets = (target, topicId, config = {}) => {
+      const postTargets = request(app.getHttpServer()).post('/targets')
+
+      const { authorized = true, expectStatus = 201 } = config
+
+      authorized && postTargets.set('Authorization', `Bearer ${accessToken}`)
+      postTargets
+        .send({ ...target, topicId })
+        .expect('Content-Type', /json/)
+
+      expectStatus && postTargets.expect(expectStatus)
+      return postTargets
+    }
+  })
+
+  afterEach(async () => {
+    await app.close()
   })
 
   describe('when sending correct token', () => {
     describe('when sending correct data', () => {
-      let response
       it('should return 201', async () => {
-        response = await request(app.getHttpServer())
-          .post('/targets')
-          .set('Authorization', `Bearer ${accessToken}`)
-          .send({ ...mockTarget, topicId: mockTopic.id })
-          .expect('Content-Type', /json/)
-          .expect(201)
+        await postTargets(mockTargets[0], mockTopic.id)
       })
 
       it('should return the newly created target', async () => {
+        const response = await postTargets(mockTargets[0], mockTopic.id)
         const target = await targets.last()
-        expect(response.body).toEqual(TargetDto.from(target))
+        expect(response.body.target).toEqual(TargetDto.from(target))
+      })
+      
+      describe('when there is another target nearby with the same topic', () => {
+        it('should create a new match', async () => {
+          const target = await targets.mockOneFromInfo(mockTargets[0], user, mockTopic)
+
+          const response = await postTargets(mockTargets[1], mockTopic.id)
+          expect(response.body.matches[0].id).toEqual(target.id)
+        })
       })
     })
 
     describe('when sending incomplete data', () => {
       it('should return 400', async () => {
-        await request(app.getHttpServer())
-          .post('/targets')
-          .set('Authorization', `Bearer ${accessToken}`)
-          .send(mockTarget) // missing topicId
-          .expect('Content-Type', /json/)
-          .expect(400)
+        await postTargets(mockTargets[1], undefined, { expectStatus: 400 })
       })
     })
 
     describe('when user has maxium targets', () => {
       it('should return 403', async () => {
         await targets.mockMany(10, user)
-        await request(app.getHttpServer())
-          .post('/targets')
-          .set('Authorization', `Bearer ${accessToken}`)
-          .send({ ...mockTarget2, topicId: mockTopic.id })
-          .expect('Content-Type', /json/)
-          .expect(403)
+        await postTargets(mockTargets[1], mockTopic.id, { expectStatus: 403 })
       })
     })
   })
 
   describe('when sending no token', () => {
     it('should return 401', async () => {
-      request(app.getHttpServer())
-        .post('/targets')
-        .expect('Content-Type', /json/)
-        .expect(401)
+      postTargets(mockTargets[1], mockTopic.id, { expectStatus: 401, authorized: false })
     })
-  })
-
-  afterAll(async () => {
-    await app.close()
   })
 })


### PR DESCRIPTION
When a target is created if there are nearby targets with the same topics, then they are matches and the matches are returned to the user.

I had to change latitude and longitude to strings because I was having various problems with other postgres data types.